### PR TITLE
Display a sample anecdote on the homepage

### DIFF
--- a/_includes/anecdote.html
+++ b/_includes/anecdote.html
@@ -1,0 +1,5 @@
+<!-- CTA -->
+<div id="anecdoteSample"></div>
+
+<script type="text/javascript" src="{{ site.baseurl }}/assets/js/showAnecdote.js"></script>
+

--- a/assets/js/showAnecdote.js
+++ b/assets/js/showAnecdote.js
@@ -18,4 +18,4 @@ containerElement.appendChild(anecdoteElement);
 containerElement.appendChild(linkElement);
 sectionElement.appendChild(containerElement);
 
-document.getElementById('banner').insertAdjacentElement('afterend', sectionElement);
+document.getElementById('anecdoteSample').appendChild(sectionElement);

--- a/assets/js/showAnecdote.js
+++ b/assets/js/showAnecdote.js
@@ -1,0 +1,21 @@
+// `an` is a global provided by assets/data/an
+var randomAnecdoteIndex = Math.floor(Math.random() * Math.floor(an.length));
+var randomAnecdote = an[randomAnecdoteIndex].anecdote;
+var anecdoteElement = document.createElement('blockquote');
+anecdoteElement.textContent = randomAnecdote;
+
+var linkElement = document.createElement('a');
+linkElement.setAttribute('href', './signatories');
+linkElement.setAttribute('title', 'View all signatories and their stories');
+linkElement.textContent = 'View more stories';
+
+var sectionElement = document.createElement('section');
+sectionElement.className = 'wrapper style2';
+var containerElement = document.createElement('p');
+containerElement.className = 'container';
+
+containerElement.appendChild(anecdoteElement);
+containerElement.appendChild(linkElement);
+sectionElement.appendChild(containerElement);
+
+document.getElementById('banner').insertAdjacentElement('afterend', sectionElement);

--- a/index.html
+++ b/index.html
@@ -13,6 +13,8 @@ layout: default
   </header>
 </section>
 
+{% include anecdote.html %}
+
 <!-- Highlights -->
 <section class="wrapper style1">
   <div class="container">
@@ -106,6 +108,3 @@ layout: default
 <!--     </div> -->
 <!--   </div> -->
 <!-- </section> -->
-
-<script type="text/javascript" src="{{ site.baseurl }}/assets/js/showAnecdote.js"></script>
-

--- a/index.html
+++ b/index.html
@@ -106,3 +106,6 @@ layout: default
 <!--     </div> -->
 <!--   </div> -->
 <!-- </section> -->
+
+<script type="text/javascript" src="{{ site.baseurl }}/assets/js/showAnecdote.js"></script>
+

--- a/signatories/index.html
+++ b/signatories/index.html
@@ -62,7 +62,7 @@ layout: default
 
 	    <hr>
 	    
-	    <!-- <p> We have collected anectodes from the ECRs who filled -->
+	    <!-- <p> We have collected anecdotes from the ECRs who filled -->
 	    <!--   out the survey - click on Details below.</p> -->
 
 	    <!-- <details>	     -->


### PR DESCRIPTION
As per @corinalogan's request: https://mobile.twitter.com/LoganCorina/status/981834006500167680

Note that you will probably want to clean up some anecdotes, such as

> My account can be found here: https://socialbat.org/2015/08/12/goals-of-science-vs-goals-of-scientists-a-love-letter-for-plos-one/

Also note that I'm currently linking to the Signatories page, as I presume all anecdotes will be shown there?

Fixes #2.